### PR TITLE
feat: decouple agreements.bill and users

### DIFF
--- a/rfc/supported-hooks.md
+++ b/rfc/supported-hooks.md
@@ -1,0 +1,64 @@
+# Hooks
+The current format of the supported hooks.
+
+## Paypal
+### Agreements billing
+For now, you may never receive a hook if:
+* An unexpected error has happen
+* Agreement already has `active` status, but there are no outstanding transactions yet
+
+#### Success
+
+Cycles billed could be 0:
+
+```json
+{
+  "meta": { "type": "paypal:agreements:billing:success" },
+  "data": {
+    "cyclesBilled": 0,
+    "agreement": {
+      "id": "I-21LTDJU14P4U",
+      "owner": "test@test.com",
+      "status": "active"
+    }
+  }
+}
+```
+
+As well as 1:
+```json
+{
+  "meta": { "type": "paypal:agreements:billing:success" },
+  "data": {
+    "cyclesBilled": 1,
+    "agreement": {
+      "id": "I-21LTDJU14P4U",
+      "owner": "test@test.com",
+      "status": "active"
+    }
+  }
+}
+```
+
+#### Failure
+
+##### Forbidden agreement status
+This error is retryable.
+Failure due to invalid agreement status, could be `cancelled` or `suspended`:
+```json
+{
+  "meta": { "type": "paypal:agreements:billing:failure" },
+  "data": {
+    "agreement": {
+      "id": "I-21LTDJU14P4U",
+      "owner": "test@test.ru",
+      "status": "cancelled"
+    },
+    "error": {
+      "code": "agreement-status-forbidden",
+      "params": { "status": "cancelled" },
+      "message": "Billing not permitted. Reason: Forbidden agreement status \"cancelled\"",
+    }
+  }
+}
+```

--- a/schemas/agreement/bill.json
+++ b/schemas/agreement/bill.json
@@ -1,6 +1,7 @@
 {
   "$id": "agreement.bill",
   "type": "object",
+  "required": ["agreement", "username"],
   "properties": {
     "agreement": {
       "type": "string"

--- a/schemas/response/agreement/create.json
+++ b/schemas/response/agreement/create.json
@@ -14,6 +14,9 @@
     },
     "agreement": {
       "$ref": "response.common.agreement#"
+    },
+    "id": {
+      "type": "string"
     }
   }
 }

--- a/schemas/transaction/sync.json
+++ b/schemas/transaction/sync.json
@@ -11,6 +11,7 @@
       "$ref": "common#/definitions/owner"
     },
     "id": {
+      "description": "Agreement ID",
       "type": "string",
       "minLength": 1
     },

--- a/src/actions/agreement/bill.js
+++ b/src/actions/agreement/bill.js
@@ -1,48 +1,53 @@
-const assert = require('assert');
 const { ActionTransport } = require('@microfleet/core');
-const { NotPermitted, HttpStatusError } = require('common-errors');
-const Promise = require('bluebird');
 const moment = require('moment');
-const get = require('get-value');
+const { error: { BillingNotPermittedError } } = require('../../utils/paypal/agreements');
 
 // helpers
 const key = require('../../redis-key');
-const resetToFreePlan = require('../../utils/reset-to-free-plan');
 const { hmget } = require('../../list-utils');
-const { PLANS_DATA, AGREEMENT_DATA, FREE_PLAN_ID } = require('../../constants');
+const { AGREEMENT_DATA, FREE_PLAN_ID } = require('../../constants');
 
 // constants
 const AGREEMENT_KEYS = ['agreement', 'plan', 'owner', 'state'];
-const PLAN_KEYS = ['subs'];
 const agreementParser = hmget(AGREEMENT_KEYS, JSON.parse, JSON);
-const planParser = hmget(PLAN_KEYS, JSON.parse, JSON);
-const kValidTxStatuses = {
-  completed: true,
+const freeAgreementPayload = (username) => ({
+  id: 'free',
+  owner: username,
+  status: 'active',
+});
+const paidAgreementPayload = (agreement, state, owner) => ({
+  owner,
+  id: agreement.id,
+  status: state.toLowerCase(),
+});
+const kBannedStates = ['cancelled', 'suspended'];
+const verifyAgreementState = (state) => {
+  if (!state || kBannedStates.includes(state.toLowerCase())) {
+    throw BillingNotPermittedError.forbiddenState(state);
+  }
+};
+const relevantTransactionsReducer = (currentCycleEnd) => (acc, it) => {
+  const status = it.status && it.status.toLowerCase();
+  const isRelevant = ['completed'].includes(status) && moment(it.time_stamp).isAfter(currentCycleEnd);
+
+  return isRelevant ? acc + 1 : acc;
 };
 
 /**
- * Parses agreement data retrieved from redis
+ * Parses and completes agreement data retrieved from redis
  * @param  {Object} service - current microfleet
  * @param  {String} id - agreement id
  * @return {Object} agreement
+ * @throws DataError When agreement data cannot be parsed
  */
-async function parseAgreementData(service, id) {
+async function buildAgreementData(service, id) {
   const { redis, log } = service;
   const agreementKey = key(AGREEMENT_DATA, id);
   const data = await redis.hmget(agreementKey, AGREEMENT_KEYS);
 
+  let parsed;
   try {
-    const parsed = agreementParser(data);
-
-    // assign owner
-    parsed.agreement.owner = parsed.owner;
-
-    // FIXME: PAYPAL agreement doesn't have embedded plan id...
-    // bug in paypal
-    parsed.agreement.plan.id = parsed.plan;
-
-    // return data
-    return parsed;
+    parsed = agreementParser(data);
   } catch (e) {
     log.error({
       err: e,
@@ -53,71 +58,32 @@ async function parseAgreementData(service, id) {
 
     throw e;
   }
-}
 
-const freeAgreementForUser = (username) => ({
-  owner: username,
-  plan: {
-    id: FREE_PLAN_ID,
-  },
-});
+  // assign owner
+  parsed.agreement.owner = parsed.owner;
 
-const kBannedStates = ['cancelled', 'suspended'];
-const verifyAgreementState = (state) => {
-  // verify state
-  if (!state || kBannedStates.includes(state.toLowerCase())) {
-    throw new NotPermitted(`Operation not permitted on "${state}" agreements.`);
-  }
-};
+  // FIXME: PAYPAL agreement doesn't have embedded plan id...
+  // bug in paypal
+  parsed.agreement.plan.id = parsed.plan;
 
-/**
- * Retrieves agreement data from redis & parses it
- * @return {Agreement}
- */
-async function getAgreement(ctx) {
-  const { id, username, service } = ctx;
-
-  if (id === FREE_PLAN_ID) {
-    return freeAgreementForUser(username);
-  }
-
-  // parsed correctly
-  const { agreement, state } = await parseAgreementData(service, id);
-  verifyAgreementState(state);
-
-  return agreement;
+  return parsed;
 }
 
 /**
- * Retrieves associated plan for requested agreement
- * @return {Object} { plan, subs }
+ * Fetch transactions from PayPal for the period [start; end]
+ * @param service
+ * @param id Agreement ID
+ * @param start
+ * @param end
+ * @param agreement
+ * @returns {bluebird<[]>}
  */
-const getPlan = async (ctx, agreement) => {
-  const { service, username } = ctx;
-  const { redis, log } = service;
-
-  const planKey = key(PLANS_DATA, agreement.plan.id);
-  const response = await redis.hmget(planKey, PLAN_KEYS);
-
-  try {
-    const { subs } = planParser(response);
-    assert(subs, 'subs not present');
-    return subs;
-  } catch (e) {
-    log.error({ response, planKey, username }, 'failed to fetch plan in redis');
-    throw e;
-  }
-};
-
-// fetch transactions from paypal
-const getTransactions = async (ctx, agreement) => {
-  const { service, id, start, end } = ctx;
-
+const getActualTransactions = async (service, agreement, start, end) => {
   if (agreement.plan.id === FREE_PLAN_ID) {
-    return {};
+    return [];
   }
-
-  const agreementData = await service.dispatch('transaction.sync', {
+  const { id } = agreement;
+  const { transactions } = await service.dispatch('transaction.sync', {
     params: {
       id,
       start,
@@ -125,101 +91,7 @@ const getTransactions = async (ctx, agreement) => {
     },
   });
 
-  return agreementData;
-};
-
-// bill next free cycle
-const billNextFreeCycle = (ctx) => {
-  const { params } = ctx;
-
-  const nextCycle = moment(params.nextCycle);
-  const current = moment();
-
-  // 0 or 1
-  ctx.cyclesBilled = Number(nextCycle.isBefore(current));
-  ctx.nextCycle = nextCycle;
-
-  // if we missed many cycles
-  if (ctx.cyclesBilled) {
-    while (nextCycle.isBefore(current)) {
-      nextCycle.add(1, 'month');
-    }
-  }
-};
-
-function billPaidCycle(ctx, details) {
-  const { params } = ctx;
-
-  // agreement nextCycle date
-  const nextCycle = moment(details.agreement.agreement_details.next_billing_date || params.nextCycle);
-  const currentCycle = moment(params.nextCycle).subtract(1, 'day');
-  const { transactions } = details;
-
-  // determine how many cycles and next billing date
-  ctx.nextCycle = nextCycle;
-  ctx.cyclesBilled = transactions.reduce((acc, it) => {
-    const status = it.status && it.status.toLowerCase();
-
-    // TODO: does paypal charge earlier?
-    // we need to filter out setup fee
-    if (kValidTxStatuses[status] && moment(it.time_stamp).isAfter(currentCycle)) {
-      return acc + 1;
-    }
-
-    return acc;
-  }, 0);
-}
-
-// verify transactions data
-const checkData = (ctx, agreement, details) => {
-  if (agreement.plan.id === FREE_PLAN_ID) {
-    return billNextFreeCycle(ctx);
-  }
-
-  if (details.transactions.length === 0) {
-    // no outstanding transactions
-    ctx.shouldUpdate = false;
-    return false;
-  }
-
-  return billPaidCycle(ctx, details);
-};
-
-const saveToRedis = async (ctx, agreement, subs) => {
-  const { updateMetadata, service, audience } = ctx;
-  const { amqp } = service;
-
-  // no updates yet - skip to next
-  if (ctx.shouldUpdate === false) {
-    return 'OK';
-  }
-
-  const planFreq = get(agreement, ['plan', 'payment_definitions', 0, 'frequency'], 'month').toLowerCase();
-  const sub = subs.find((x) => x.name === planFreq);
-
-  if (!sub) {
-    ctx.log.error({ subs, agreement, planFreq }, 'failed to fetch subs');
-    throw new HttpStatusError(500, 'internal application error');
-  }
-
-  const models = sub.models * ctx.cyclesBilled;
-
-  const updateRequest = {
-    username: agreement.owner,
-    audience,
-    metadata: {
-      $set: {
-        nextCycle: ctx.nextCycle.valueOf(),
-      },
-      $incr: {
-        models,
-      },
-    },
-  };
-
-  await amqp.publishAndWait(updateMetadata, updateRequest, { timeout: 15000 });
-
-  return 'OK';
+  return transactions;
 };
 
 /**
@@ -232,54 +104,72 @@ const saveToRedis = async (ctx, agreement, subs) => {
  * @apiSchema {jsonschema=response/agreement/bill.json} apiResponse
  */
 async function agreementBill({ log, params }) {
-  const { agreement: id, subscriptionInterval, username } = params;
-  const { config } = this;
-  const { users: { prefix, postfix } } = config;
-  const start = moment().subtract(2, subscriptionInterval).format('YYYY-MM-DD');
-  const end = moment().add(1, 'day').format('YYYY-MM-DD');
+  const { agreement: id, subscriptionInterval, username, nextCycle } = params;
+  const now = moment();
+  const start = now.subtract(2, subscriptionInterval).format('YYYY-MM-DD');
+  const end = now.add(1, 'day').format('YYYY-MM-DD');
 
   log.debug('billing %s on %s', username, id);
 
-  const ctx = {
-    service: this,
-    log,
+  if (id === FREE_PLAN_ID) {
+    // @todo message builder, pass publish options
+    await this.amqp.publish('payments.hook.publish', {
+      event: 'paypal:agreements:billing:success',
+      payload: {
+        agreement: freeAgreementPayload(username),
+        cyclesBilled: Number(nextCycle.isBefore(now)),
+      },
+    });
 
-    // used params
-    id,
-    username,
-    start,
-    end,
-    params,
-    audience: config.users.audience,
+    return 'OK';
+  }
 
-    // pre-calculated vars
-    updateMetadata: `${prefix}.${postfix.updateMetadata}`,
-  };
+  const { agreement, state } = await buildAgreementData(this, id);
 
   try {
-    const agreement = await getAgreement(ctx);
+    verifyAgreementState(state);
+  } catch (error) {
+    if (error instanceof BillingNotPermittedError) {
+      log.warn({ err: error }, 'Agreement %s was cancelled by user %s', id, username);
+      // @todo message builder, pass publish options
+      await this.amqp.publish('payments.hook.publish', {
+        event: 'paypal:agreements:billing:failure',
+        payload: {
+          error,
+          agreement: paidAgreementPayload(agreement, state, username),
+        },
+      });
 
-    const [subs, details] = await Promise.all([
-      getPlan(ctx, agreement),
-      getTransactions(ctx, agreement),
-    ]);
+      return 'FAIL';
+    }
+    // 'failed to fetch agreement data' or unexpected error
+    log.warn({ err: error }, 'Failed to sync', username, id);
+    throw error;
+  }
 
-    checkData(ctx, agreement, details);
-
-    return await saveToRedis(ctx, agreement, subs);
+  let transactions;
+  try {
+    transactions = await getActualTransactions(this, agreement, start, end);
+    log.debug('fetched transactions for agreement %s created from %s to %s', id, start, end);
   } catch (e) {
-    if (e instanceof NotPermitted) {
-      log.warn({ err: e }, 'Agreement %s was cancelled by user %s', username, id);
-      return resetToFreePlan.call(this, username);
-    }
-
-    if (e.statusCode === 400 && e.message === 'The profile ID is invalid') {
-      return resetToFreePlan.call(this, username);
-    }
-
     log.warn({ err: e }, 'Failed to sync', username, id);
+
     throw e;
   }
+
+  if (agreement.plan.id === FREE_PLAN_ID || transactions.length !== 0) {
+    const currentCycleEnd = moment(params.nextCycle).subtract(1, 'day');
+    // @todo message builder, pass publish options
+    await this.amqp.publish('payments.hook.publish', {
+      event: 'paypal:agreements:billing:success',
+      payload: {
+        agreement: paidAgreementPayload(agreement, state, username),
+        cyclesBilled: transactions.reduce(relevantTransactionsReducer(currentCycleEnd), 0),
+      },
+    });
+  }
+
+  return 'OK';
 }
 
 agreementBill.transports = [ActionTransport.amqp, ActionTransport.internal];

--- a/src/actions/agreement/bill.js
+++ b/src/actions/agreement/bill.js
@@ -132,10 +132,11 @@ async function agreementBill({ log, params }) {
     if (error instanceof BillingNotPermittedError) {
       log.warn({ err: error }, 'Agreement %s was cancelled by user %s', id, username);
       // @todo message builder, pass publish options
+      const { message, code, params: errorParams } = error;
       await this.amqp.publish('payments.hook.publish', {
         event: 'paypal:agreements:billing:failure',
         payload: {
-          error,
+          error: { message, code, params: errorParams },
           agreement: paidAgreementPayload(agreement, state, username),
         },
       });

--- a/src/actions/hook/publish.js
+++ b/src/actions/hook/publish.js
@@ -9,7 +9,7 @@ const { ActionTransport } = require('@microfleet/core');
  * @apiSchema {jsonschema=hook/publish.json} apiRequest
  * @apiSchema {jsonschema=response/hook/publish.json} apiResponse
  */
-async function hookPublish({ params }) {
+function hookPublish({ params }) {
   const { event, payload } = params;
 
   return this.eventBus.publish(event, {

--- a/src/list-utils.js
+++ b/src/list-utils.js
@@ -48,6 +48,7 @@ function hmget(fields, func = passThrough, ctx, defaults) {
     return fields.reduce((acc, field, idx) => {
       const datum = data[idx] || defaults;
       acc[field] = func.call(ctx || this, datum);
+
       return acc;
     }, {});
   };

--- a/src/utils/event-bus/publisher/amqp/amqp.js
+++ b/src/utils/event-bus/publisher/amqp/amqp.js
@@ -9,7 +9,7 @@ class AMQPPublisher {
   }
 
   /**
-   * @todo check result is 200
+   * @todo check result is OK
    * @todo set up timeout
    *
    * @param {String} route

--- a/src/utils/paypal/agreements/error/billing-incomplete-error.js
+++ b/src/utils/paypal/agreements/error/billing-incomplete-error.js
@@ -1,0 +1,7 @@
+class BillingIncompleteError extends Error {
+  constructor() {
+    super('Billing incomplete. Agreement state is active, but there is no outstanding transactions. Please retry later.');
+  }
+}
+
+module.exports = BillingIncompleteError;

--- a/src/utils/paypal/agreements/error/billing-not-permitted-error.js
+++ b/src/utils/paypal/agreements/error/billing-not-permitted-error.js
@@ -1,0 +1,16 @@
+const CODE_AGREEMENT_STATE_FORBIDDEN = 'agreement-state-forbidden';
+
+class BillingNotPermittedError extends Error {
+  constructor(reason) {
+    super(`Billing not permitted. Reason: ${reason}`);
+  }
+
+  static forbiddenState(state) {
+    const error = new BillingNotPermittedError(`Forbidden agreement state "${state}"`);
+    error.code = CODE_AGREEMENT_STATE_FORBIDDEN;
+    error.meta = { state };
+    return error;
+  }
+}
+
+module.exports = BillingNotPermittedError;

--- a/src/utils/paypal/agreements/error/billing-not-permitted-error.js
+++ b/src/utils/paypal/agreements/error/billing-not-permitted-error.js
@@ -1,14 +1,14 @@
-const CODE_AGREEMENT_STATE_FORBIDDEN = 'agreement-state-forbidden';
+const CODE_AGREEMENT_STATUS_FORBIDDEN = 'agreement-status-forbidden';
 
 class BillingNotPermittedError extends Error {
   constructor(reason) {
     super(`Billing not permitted. Reason: ${reason}`);
   }
 
-  static forbiddenState(state) {
-    const error = new BillingNotPermittedError(`Forbidden agreement state "${state}"`);
-    error.code = CODE_AGREEMENT_STATE_FORBIDDEN;
-    error.params = { state };
+  static forbiddenState(status) {
+    const error = new BillingNotPermittedError(`Forbidden agreement status "${status}"`);
+    error.code = CODE_AGREEMENT_STATUS_FORBIDDEN;
+    error.params = { status };
     return error;
   }
 }

--- a/src/utils/paypal/agreements/error/billing-not-permitted-error.js
+++ b/src/utils/paypal/agreements/error/billing-not-permitted-error.js
@@ -8,7 +8,7 @@ class BillingNotPermittedError extends Error {
   static forbiddenState(state) {
     const error = new BillingNotPermittedError(`Forbidden agreement state "${state}"`);
     error.code = CODE_AGREEMENT_STATE_FORBIDDEN;
-    error.meta = { state };
+    error.params = { state };
     return error;
   }
 }

--- a/src/utils/paypal/agreements/error/index.js
+++ b/src/utils/paypal/agreements/error/index.js
@@ -1,0 +1,5 @@
+const BillingNotPermittedError = require('./billing-not-permitted-error');
+
+module.exports = {
+  BillingNotPermittedError,
+};

--- a/src/utils/paypal/agreements/error/index.js
+++ b/src/utils/paypal/agreements/error/index.js
@@ -1,5 +1,7 @@
 const BillingNotPermittedError = require('./billing-not-permitted-error');
+const BillingIncompleteError = require('./billing-incomplete-error');
 
 module.exports = {
   BillingNotPermittedError,
+  BillingIncompleteError,
 };

--- a/src/utils/paypal/agreements/index.js
+++ b/src/utils/paypal/agreements/index.js
@@ -1,0 +1,5 @@
+const error = require('./error');
+
+module.exports = {
+  error,
+};

--- a/test/configs/subscriptions.js
+++ b/test/configs/subscriptions.js
@@ -1,0 +1,21 @@
+const publishing = {
+  retry: {
+    enabled: false,
+  },
+};
+
+exports.subscriptions = {
+  events: {
+    'paypal:agreements:execution:success': [],
+    'paypal:agreements:execution:failure': [],
+    'paypal:agreements:billing:success': {
+      endpoint: 'ms-billing.paypal.agreements.billing.success',
+      publishing,
+    },
+    'paypal:agreements:billing:failure': [{
+      endpoint: 'ms-billing.paypal.agreements.billing.failure',
+      publishing,
+    }],
+    'paypal:transactions:create': [],
+  },
+};

--- a/test/e2e/suites/02-agreements.js
+++ b/test/e2e/suites/02-agreements.js
@@ -124,11 +124,8 @@ describe('Agreements suite', function AgreementSuite() {
       const result = await dispatch(billAgreement, { agreement: id, nextCycle: Date.now(), username: 'test@test.ru' });
 
       assert.strictEqual(result, 'OK');
-
-      const hookPublishCalls = publishStub.getCalls().filter((call) => call.firstArg === 'payments.hook.publish');
-      assert.strictEqual(hookPublishCalls.length, 1);
       sinon.assert.calledWithExactly(
-        hookPublishCalls[0],
+        publishStub,
         'payments.hook.publish',
         sinon.match({
           event: 'paypal:agreements:billing:success',
@@ -143,6 +140,8 @@ describe('Agreements suite', function AgreementSuite() {
         }),
         sinon.match({ confirm: true, deliveryMode: 2, mandatory: true, priority: 0 })
       );
+      const hookPublishCalls = publishStub.getCalls().filter((call) => call.firstArg === 'payments.hook.publish');
+      assert.strictEqual(hookPublishCalls.length, 1);
     });
 
     it('Should create a trial agreement', async () => {
@@ -211,11 +210,8 @@ describe('Agreements suite', function AgreementSuite() {
 
       const result = await dispatch(billAgreement, { agreement: id, nextCycle: Date.now(), username: 'test@test.ru' });
       assert.strictEqual(result, 'FAIL');
-
-      const hookPublishCalls = publishStub.getCalls().filter((call) => call.firstArg === 'payments.hook.publish');
-      assert.strictEqual(hookPublishCalls.length, 1);
       sinon.assert.calledWithExactly(
-        hookPublishCalls[0],
+        publishStub,
         'payments.hook.publish',
         sinon.match({
           event: 'paypal:agreements:billing:failure',
@@ -230,6 +226,8 @@ describe('Agreements suite', function AgreementSuite() {
         }),
         sinon.match({ confirm: true, deliveryMode: 2, mandatory: true, priority: 0 })
       );
+      const hookPublishCalls = publishStub.getCalls().filter((call) => call.firstArg === 'payments.hook.publish');
+      assert.strictEqual(hookPublishCalls.length, 1);
     });
 
     it('Should get free agreement for user after cancelling', async () => {

--- a/test/e2e/suites/02-agreements.js
+++ b/test/e2e/suites/02-agreements.js
@@ -207,9 +207,9 @@ describe('Agreements suite', function AgreementSuite() {
           event: 'paypal:agreements:billing:failure',
           payload: sinon.match({
             error: sinon.match({
-              message: 'Billing not permitted. Reason: Forbidden agreement state "cancelled"',
-              code: 'agreement-state-forbidden',
-              params: sinon.match({ state: 'cancelled' }),
+              message: 'Billing not permitted. Reason: Forbidden agreement status "cancelled"',
+              code: 'agreement-status-forbidden',
+              params: sinon.match({ status: 'cancelled' }),
             }),
             agreement: sinon.match({ id, owner: 'test@test.ru', status: 'cancelled' }),
           }),
@@ -225,7 +225,11 @@ describe('Agreements suite', function AgreementSuite() {
       sinon.assert.calledWithExactly(hookPublishCalls[0], 'payments.hook.publish', sinon.match({
         event: 'paypal:agreements:billing:failure',
         payload: sinon.match({
-          error: sinon.match({ code: 'agreement-state-forbidden', meta: { state: 'cancelled' } }),
+          error: sinon.match({
+            message: 'Billing not permitted. Reason: Forbidden agreement status "cancelled"',
+            code: 'agreement-status-forbidden',
+            params: sinon.match({ status: 'cancelled' }),
+          }),
           agreement: sinon.match({ id, owner: 'test@test.ru', status: 'cancelled' }),
         }),
       }));

--- a/test/e2e/suites/02-agreements.js
+++ b/test/e2e/suites/02-agreements.js
@@ -206,7 +206,11 @@ describe('Agreements suite', function AgreementSuite() {
         .withArgs('payments.hook.publish', sinon.match({
           event: 'paypal:agreements:billing:failure',
           payload: sinon.match({
-            error: sinon.match.object,
+            error: sinon.match({
+              message: 'Billing not permitted. Reason: Forbidden agreement state "cancelled"',
+              code: 'agreement-state-forbidden',
+              params: sinon.match({ state: 'cancelled' }),
+            }),
             agreement: sinon.match({ id, owner: 'test@test.ru', status: 'cancelled' }),
           }),
         }))


### PR DESCRIPTION
Uses [event subscriptions](https://github.com/makeomatic/ms-payments/pull/131)
`agreements.bill` action is deliberately messy and straightforward, I will gradually isolate good common parts and then polish.