### PR TITLE
fix: update agreement.bill logic

### DIFF
--- a/rfc/supported-hooks.md
+++ b/rfc/supported-hooks.md
@@ -135,7 +135,7 @@ Failure due to invalid agreement status, could be `cancelled` or `suspended`:
 }
 ```
 
-##### Incriased failed payment count.
+##### Increased failed payment count.
 This error is retryable.
 Failure due to increased `failed_payment_count` on Agreement. Generally, this happens when PayPal was unable to bill the next billing cycle and will retry later.
 ```json

--- a/rfc/supported-hooks.md
+++ b/rfc/supported-hooks.md
@@ -135,21 +135,24 @@ Failure due to invalid agreement status, could be `cancelled` or `suspended`:
 }
 ```
 
-##### No transactions for period
+##### Incriased failed payment count.
 This error is retryable.
-Failure due to the absence of the transactions for the required billing cycle. Generally, this happens when PayPal was unable to bill the next billing cycle and will retry later.
+Failure due to increased `failed_payment_count` on Agreement. Generally, this happens when PayPal was unable to bill the next billing cycle and will retry later.
 ```json
 {
   "meta": { "type": "paypal:agreements:billing:failure" },
   "data": {
     "error": {
-      "code": "agreement-status-forbidden",
+      "code": "agreement-payment-failed",
       "params": {
         "agreementId": "I-21LTDJU14P4U",
         "owner": "test@test.ru",
-        "period": { "start": "YYYY-MM-DD", "end": "YYYY-MM-DD" }
+        "failedCount": {
+          "local": 1,
+          "remote": 2,
+        },
       },
-      "message": "Agreement billing failed. Reason: Agreement \"I-21LTDJU14P4U\" has no transactions for period"
+      "message": "Agreement billing failed. Reason: Agreement \"I-21LTDJU14P4U\" as increased failed payment count"
     }
   }
 }

--- a/rfc/supported-hooks.md
+++ b/rfc/supported-hooks.md
@@ -134,3 +134,23 @@ Failure due to invalid agreement status, could be `cancelled` or `suspended`:
   }
 }
 ```
+
+##### No transactions for period
+This error is retryable.
+Failure due to the absence of the transactions for the required billing cycle. Generally, this happens when PayPal was unable to bill the next billing cycle and will retry later.
+```json
+{
+  "meta": { "type": "paypal:agreements:billing:failure" },
+  "data": {
+    "error": {
+      "code": "agreement-status-forbidden",
+      "params": {
+        "agreementId": "I-21LTDJU14P4U",
+        "owner": "test@test.ru",
+        "period": { "start": "YYYY-MM-DD", "end": "YYYY-MM-DD" }
+      },
+      "message": "Agreement billing failed. Reason: Agreement \"I-21LTDJU14P4U\" has no transactions for period"
+    }
+  }
+}
+```

--- a/rfc/supported-hooks.md
+++ b/rfc/supported-hooks.md
@@ -82,10 +82,15 @@ Paypal has not found token
 ### Agreements billing
 For now, you may never receive a hook if:
 * An unexpected error has happen
-* Agreement already has `active` status, but there are no outstanding transactions yet
+
+`Agreement.bill` will execute hooks:
+
+1. `billing:failure` hook when `agreement_details.failed_payment_count` increased and `agreement_details.cycles_complete` not increased. This condition means that PayPal will retry in a log future.
+2. `billing:success` hook:
+    * With `cyclesBilled === 0`, the receiver should retry the billing request in a while and wait for agreement_details.complete_cycles to increase. This condition means that PayPal didn't billed cycle.
+    * With `cyclesBilled > 0`, generally means that everything billed successfully.
 
 #### Success
-
 Cycles billed could be 0:
 
 ```json

--- a/src/actions/agreement/execute.js
+++ b/src/actions/agreement/execute.js
@@ -229,7 +229,7 @@ async function agreementExecute({ params }) {
     throw e;
   }
 
-  // todo Why do we need plan merge?
+  // Paypal provides limited plan info and we should merge it with extra data
   const agreement = { ...updatedAgreement, plan: mergeWithNotNull(agreementData.plan, updatedAgreement.plan) };
 
   await publishSuccessHook(amqp, successPayload(agreement, token, planId, owner));

--- a/src/utils/paypal/agreements/error/billing-error.js
+++ b/src/utils/paypal/agreements/error/billing-error.js
@@ -1,4 +1,5 @@
 const CODE_AGREEMENT_STATUS_FORBIDDEN = 'agreement-status-forbidden';
+const CODE_AGREEMENT_STATUS_NO_TRANSACTIONS = 'agreement-no-transactions';
 
 class BillingError extends Error {
   constructor(reason) {
@@ -9,6 +10,13 @@ class BillingError extends Error {
     const error = new BillingError(`Agreement "${agreementId}" has status "${status}"`);
     error.code = CODE_AGREEMENT_STATUS_FORBIDDEN;
     error.params = { agreementId, owner, status };
+    return error;
+  }
+
+  static noRelevantTransactions(agreementId, owner, period) {
+    const error = new BillingError(`Agreement "${agreementId}" has no transactions for period`);
+    error.code = CODE_AGREEMENT_STATUS_NO_TRANSACTIONS;
+    error.params = { agreementId, owner, period };
     return error;
   }
 }

--- a/src/utils/paypal/agreements/error/billing-error.js
+++ b/src/utils/paypal/agreements/error/billing-error.js
@@ -1,9 +1,17 @@
 const CODE_AGREEMENT_STATUS_FORBIDDEN = 'agreement-status-forbidden';
-const CODE_AGREEMENT_STATUS_NO_TRANSACTIONS = 'agreement-no-transactions';
+const CODE_AGREEMENT_PAYMENT_FAILED = 'agreement-payment-failed';
 
 class BillingError extends Error {
   constructor(reason) {
     super(`Agreement billing failed. Reason: ${reason}`);
+  }
+
+  getHookErrorData() {
+    return {
+      message: this.message,
+      code: this.code,
+      params: this.params,
+    };
   }
 
   static agreementStatusForbidden(agreementId, owner, status) {
@@ -13,10 +21,10 @@ class BillingError extends Error {
     return error;
   }
 
-  static noRelevantTransactions(agreementId, owner, period) {
-    const error = new BillingError(`Agreement "${agreementId}" has no transactions for period`);
-    error.code = CODE_AGREEMENT_STATUS_NO_TRANSACTIONS;
-    error.params = { agreementId, owner, period };
+  static hasIncreasedPaymentFailure(agreementId, owner, failedCount) {
+    const error = new BillingError(`Agreement "${agreementId}" has increased failed payment count`);
+    error.code = CODE_AGREEMENT_PAYMENT_FAILED;
+    error.params = { agreementId, owner, failedCount };
     return error;
   }
 }

--- a/test/e2e/suites/01-transactions.js
+++ b/test/e2e/suites/01-transactions.js
@@ -91,13 +91,12 @@ describe('Transactions suite', function TransactionsSuite() {
       const start = moment().startOf('day').subtract(1, 'day').format('YYYY-MM-DD');
       const end = moment().endOf('month').add(1, 'day').format('YYYY-MM-DD');
 
-      let state = 'Pending';
+      let count = 0;
       /* eslint-disable no-await-in-loop */
-      while (state === 'Pending') {
-        const { agreement: aggr, transactions } = await dispatch(syncTransaction, { id: agreement.id, start, end });
-        state = aggr.state;
-        if (state === 'Pending' || transactions.length === 0) {
-          state = 'Pending';
+      while (count === 0) {
+        const { transactions } = await dispatch(syncTransaction, { id: agreement.id, start, end });
+        if (transactions.length !== 0) {
+          count = transactions.length;
           await Promise.delay(5000);
         }
       }

--- a/test/helpers/chrome.js
+++ b/test/helpers/chrome.js
@@ -12,6 +12,8 @@ const RETRY_LINK = '#retryLink';
 const HAS_ACCOUNT_LINK = '.baslLoginButtonContainer .btn';
 const LOGIN_BUTTON = '#btnLogin';
 
+const GDPR_BTN = '#acceptAllButton';
+
 // instance variables
 let page;
 let chrome;
@@ -173,6 +175,14 @@ exports.approveSubscription = saveCrashReport(async (saleUrl) => {
   await typeAndSubmit(EMAIL_INPUT, process.env.PAYPAL_SANDBOX_USERNAME);
   await typeAndSubmit(PWD_INPUT, process.env.PAYPAL_SANDBOX_PASSWORD);
 
+  const gdprBtn = await page.$(GDPR_BTN);
+  if (gdprBtn) {
+    console.info('accept gdpr');
+    await Promise.delay(3000);
+    await page.click(GDPR_BTN, { delay: 100 });
+    await dispose(gdprBtn);
+  }
+
   try {
     console.info('[after login] --> ', page.url());
     await confirmRetry(RETRY_LINK, CONFIRM_BUTTON, /paypal-subscription-return\?/);
@@ -216,6 +226,14 @@ exports.approveSale = saveCrashReport(async (saleUrl, regexp = /paypal-sale-retu
     await Promise.delay(3000);
     await Promise.all([idle('2'), hasAccount.click({ delay: 100 })]);
     await dispose(hasAccount);
+  }
+
+  const gdprBtn = await page.$(GDPR_BTN);
+  if (gdprBtn) {
+    console.info('accept gdpr');
+    await Promise.delay(3000);
+    await page.click(GDPR_BTN, { delay: 100 });
+    await dispose(gdprBtn);
   }
 
   await typeAndSubmit(EMAIL_INPUT, process.env.PAYPAL_SANDBOX_USERNAME);

--- a/test/helpers/chrome.js
+++ b/test/helpers/chrome.js
@@ -229,6 +229,9 @@ exports.approveSale = saveCrashReport(async (saleUrl, regexp = /paypal-sale-retu
     await dispose(hasAccount);
   }
 
+  await typeAndSubmit(EMAIL_INPUT, process.env.PAYPAL_SANDBOX_USERNAME);
+  await typeAndSubmit(PWD_INPUT, process.env.PAYPAL_SANDBOX_PASSWORD);
+
   const gdprBtn = await page.$(GDPR_BTN);
   if (gdprBtn) {
     console.info('accept gdpr');
@@ -236,9 +239,6 @@ exports.approveSale = saveCrashReport(async (saleUrl, regexp = /paypal-sale-retu
     await page.click(GDPR_BTN, { delay: 100 });
     await dispose(gdprBtn);
   }
-
-  await typeAndSubmit(EMAIL_INPUT, process.env.PAYPAL_SANDBOX_USERNAME);
-  await typeAndSubmit(PWD_INPUT, process.env.PAYPAL_SANDBOX_PASSWORD);
 
   try {
     console.info('[after login] --> ', page.url());

--- a/test/helpers/chrome.js
+++ b/test/helpers/chrome.js
@@ -176,6 +176,7 @@ exports.approveSubscription = saveCrashReport(async (saleUrl) => {
   await typeAndSubmit(PWD_INPUT, process.env.PAYPAL_SANDBOX_PASSWORD);
 
   const gdprBtn = await page.$(GDPR_BTN);
+  console.info('[gdpr button]', { gdprBtn });
   if (gdprBtn) {
     console.info('accept gdpr');
     await Promise.delay(3000);


### PR DESCRIPTION
**Breaking change:** Agreement data only synced on `agreement.execute` and `agreement.bill`. Removes agreement synchronisation from `transactions.sync`.  This change is required for comparing agreement status in `agreement.bill` action.

As a workaround, we should create hooks to receive updated agreement information from PayPal.

`agreement.bill` notify `billing:success` or `billing:failure` hook when there are no transactions for a selected period. 
1. Call `billing:failure` hook for billing request when `agreement_details.failed_payment_count` increased and `agreement_details.cycles_complete` not increased. This condition means that PayPal will retry in a log future.
2. Call `billing:success` hook otherwise. The receiver should retry the billing request in a while and wait for `agreement_details.complete_cycles` to increase. This condition means that PayPal didn't billed cycle.